### PR TITLE
ユーザ一覧と詳細画面の実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,8 +4,11 @@ Rails:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+Style/Lambda:
+  Enabled: false
+
 Metrics/LineLength:
-  Max: 120
+  Max: 150
 
 Rails/HasAndBelongsToMany:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'bootstrap', '~> 4.1.1'
 gem 'haml-rails'
 gem 'simple_form'
 gem 'kaminari'
+gem "font-awesome-rails"
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,8 @@ GEM
     faker (1.8.7)
       i18n (>= 0.7)
     ffi (1.9.23)
+    font-awesome-rails (4.7.0.4)
+      railties (>= 3.2, < 6.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     haml (5.0.4)
@@ -318,6 +320,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
+  font-awesome-rails
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -9,6 +9,7 @@
  * compiled file so the styles you add here take precedence over styles defined in any other CSS/SCSS
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
+ *= require font-awesome
  *
  */
 @import "bootstrap"

--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -13,3 +13,4 @@
  */
 @import "bootstrap"
 @import "initializers/default"
+@import "overrides/custom"

--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -13,5 +13,4 @@
  *
  */
 @import "bootstrap"
-@import "initializers/default"
 @import "overrides/custom"

--- a/app/assets/stylesheets/initializers/default.sass
+++ b/app/assets/stylesheets/initializers/default.sass
@@ -1,2 +1,0 @@
-.rounded-circle
-  width: 35px

--- a/app/assets/stylesheets/overrides/custom.sass
+++ b/app/assets/stylesheets/overrides/custom.sass
@@ -1,0 +1,9 @@
+@import "bootstrap"
+
+.rounded-circle-sm
+  @extend .rounded-circle !optional
+  width: 35px
+
+.rounded-circle-lg
+  @extend .rounded-circle !optional
+  width: 100px

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    added_attrs = %i[name email password password_confirmation remember_me avatar]
+    added_attrs = %i[name email password password_confirmation remember_me avatar profile]
     devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
     devise_parameter_sanitizer.permit :account_update, keys: added_attrs
   end

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -18,7 +18,7 @@ class TweetsController < ApplicationController
   def destroy
     @tweet = current_user.tweets.find(params[:id])
     @tweet.destroy
-    redirect_to request.referer || :root, notice: '削除しました'
+    redirect_to request.referer, notice: '削除しました'
   end
 
   private

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -18,7 +18,7 @@ class TweetsController < ApplicationController
   def destroy
     @tweet = current_user.tweets.find(params[:id])
     @tweet.destroy
-    redirect_to root_path, notice: '削除しました'
+    redirect_to request.referer || :root, notice: '削除しました'
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,16 +1,16 @@
 class UsersController < ApplicationController
   def index
-    @users = User.all
+    @users = User.recent.page params[:page]
     @user = User.new
   end
 
   def show
     @user = User.find(params[:id])
-    @tweets = @user.tweets.order('created_at desc')
+    @tweets = @user.tweets.recent
   end
 
   def search
-    @users = User.search(params[:search])
+    @users = User.recent.search(params[:search]).page params[:page]
     render action: :index
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,16 +1,11 @@
 class UsersController < ApplicationController
   def index
-    @users = User.recent.page params[:page]
+    @users = User.recent.search(params[:keyword]).page params[:page]
     @user = User.new
   end
 
   def show
     @user = User.find(params[:id])
     @tweets = @user.tweets.recent.page params[:page]
-  end
-
-  def search
-    @users = User.recent.search(params[:search]).page params[:page]
-    render action: :index
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,10 +1,16 @@
 class UsersController < ApplicationController
   def index
     @users = User.all
+    @user = User.new
   end
 
   def show
     @user = User.find(params[:id])
     @tweets = @user.tweets.order('created_at desc')
+  end
+
+  def search
+    @users = User.search(params[:name])
+    render action: :index
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-    @tweets = @user.tweets.recent
+    @tweets = @user.tweets.recent.page params[:page]
   end
 
   def search

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
   end
 
   def search
-    @users = User.search(params[:name])
+    @users = User.search(params[:search])
     render action: :index
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,8 @@
 class UsersController < ApplicationController
+  def index
+    @users = User.all
+  end
+
   def show
     @user = User.find(params[:id])
     @tweets = @user.tweets.order('created_at desc')

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,6 @@
+class UsersController < ApplicationController
+  def show
+    @user = User.find(params[:id])
+    @tweets = @user.tweets.order('created_at desc')
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,9 @@
 module ApplicationHelper
-  def avatar_image(user)
+  def avatar_image(user, image_class)
     if user.avatar.attached?
-      image_tag user.avatar, class: 'rounded-circle-sm'
+      image_tag user.avatar, class: image_class
     else
-      image_tag '/no_image.png', class: 'rounded-circle-sm'
+      image_tag '/no_image.png', class: image_class
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
   scope :recent, -> { order('created_at desc') }
 
   def self.search(search)
-    if search
+    if search.present?
       User.where(['name LIKE ?', "%#{search}%"]).or(User.where(['profile LIKE ?', "%#{search}%"]))
     else
       User.all

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,12 @@ class User < ApplicationRecord
   validates :name, presence: true, uniqueness: { case_sensitive: false }
   has_one_attached :avatar
   has_many :tweets, dependent: :destroy
+
+  def self.search(name)
+    if name
+      User.where(['name LIKE ?', "%#{name}%"])
+    else
+      User.all
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ApplicationRecord
   has_one_attached :avatar
   has_many :tweets, dependent: :destroy
 
+  scope :recent, -> { order('created_at desc') }
+
   def self.search(search)
     if search
       User.where(['name LIKE ?', "%#{search}%"]).or(User.where(['profile LIKE ?', "%#{search}%"]))

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,9 +5,9 @@ class User < ApplicationRecord
   has_one_attached :avatar
   has_many :tweets, dependent: :destroy
 
-  def self.search(name)
-    if name
-      User.where(['name LIKE ?', "%#{name}%"])
+  def self.search(search)
+    if search
+      User.where(['name LIKE ?', "%#{search}%"]).or(User.where(['profile LIKE ?', "%#{search}%"]))
     else
       User.all
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,12 +6,10 @@ class User < ApplicationRecord
   has_many :tweets, dependent: :destroy
 
   scope :recent, -> { order('created_at desc') }
-
-  def self.search(search)
-    if search.present?
-      User.where(['name LIKE ?', "%#{search}%"]).or(User.where(['profile LIKE ?', "%#{search}%"]))
-    else
-      User.all
+  scope :search, ->(keyword) {
+    if keyword.present?
+      where('name LIKE :keyword OR profile LIKE :keyword',
+            keyword: "%#{sanitize_sql_like(keyword)}%")
     end
-  end
+  }
 end

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -8,6 +8,7 @@
           = f.input :avatar do
             = f.file_field :avatar, class: "form-control"
           = f.input :email
+          = f.input :profile
           = f.input :password, autocomplete: "off"
           = f.input :password_confirmation, autocomplete: "off"
           = f.input :current_password, autocomplete: "off"

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -6,10 +6,10 @@
         = simple_form_for(resource, as: resource_name, url: :user_registration, html: { method: :put }) do |f|
           = f.input :name
           = f.input :avatar do
-            = f.file_field :avatar, class: "form-control"
+            = f.file_field :avatar, class: 'form-control'
           = f.input :email
           = f.input :profile
-          = f.input :password, autocomplete: "off"
-          = f.input :password_confirmation, autocomplete: "off"
-          = f.input :current_password, autocomplete: "off"
+          = f.input :password, autocomplete: 'off'
+          = f.input :password_confirmation, autocomplete: 'off'
+          = f.input :current_password, autocomplete: 'off'
           = f.submit '変更を保存', class: 'btn btn-primary badge-pill'

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -4,5 +4,5 @@
     = simple_form_for(resource, as: resource_name, url: :user_registration) do |f|
       = f.input :name, required: false
       = f.input :email
-      = f.input :password, autocomplete: "off"
+      = f.input :password, autocomplete: 'off'
       = f.submit 'アカウント作成', class: 'btn btn-primary badge-pill'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -3,7 +3,7 @@
     %h4 TwitterCloneにログイン
     = simple_form_for(resource, as: resource_name, url: :user_session) do |f|
       = f.input :email
-      = f.input :password, autocomplete: "off"
+      = f.input :password, autocomplete: 'off'
       = f.submit 'ログイン', class:'btn btn-primary'
       - if devise_mapping.rememberable?
         = f.check_box :remember_me

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -1,17 +1,17 @@
 - if controller_name != 'sessions'
-  = link_to "Log in", new_session_path(resource_name)
+  = link_to 'Log in', new_session_path(resource_name)
   %br/
 - if devise_mapping.registerable? && controller_name != 'registrations'
-  = link_to "Sign up", new_registration_path(resource_name)
+  = link_to 'Sign up', new_registration_path(resource_name)
   %br/
 - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
-  = link_to "Forgot your password?", new_password_path(resource_name)
+  = link_to 'Forgot your password?', new_password_path(resource_name)
   %br/
 - if devise_mapping.confirmable? && controller_name != 'confirmations'
-  = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)
+  = link_to 'Didn't receive confirmation instructions?', new_confirmation_path(resource_name)
   %br/
 - if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
-  = link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name)
+  = link_to 'Didn't receive unlock instructions?', new_unlock_path(resource_name)
   %br/
 - if devise_mapping.omniauthable?
   - resource_class.omniauth_providers.each do |provider|

--- a/app/views/layouts/_flash.html.haml
+++ b/app/views/layouts/_flash.html.haml
@@ -1,4 +1,4 @@
 - flash.each do |key, value|
-  - key = "info" if key == "notice"
-  - key = "danger"  if key == "alert"
+  - key = 'info' if key == 'notice'
+  - key = 'danger'  if key == 'alert'
   = content_tag(:div, value, class: "alert alert-#{key}")

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -1,8 +1,16 @@
-%nav.navbar.navbar-light.bg-light
-  %a.navbar-brand{href: "/"} Twitter Clone
-  %ul.navbar-nav
+%nav.navbar.navbar-expand-lg.navbar-light.bg-light
+  .navbar-brand
+    = link_to :root do
+      = fa_icon "home", text: "ホーム"
+  %button.navbar-toggler{"aria-controls" => "navbarText", "aria-expanded" => "false", "aria-label" => "Toggle navigation", "data-target" => "#navbarText", "data-toggle" => "collapse", :type => "button"}
+    %span.navbar-toggler-icon
+  #navbarText.collapse.navbar-collapse
     - if user_signed_in?
-      %li.nav-item.dropdown
+      %ul.navbar-nav.mr-auto
+        %li.nav-item
+          = link_to root_path do
+            = fa_icon "users", text: "ユーザー"
+      .nav-item.dropdown
         = link_to("#", id: "navbarDropdownMenuLink", class: "nav-link dropdown-toggle", "data-toggle": "dropdown", "data-flip": "true", "aria-haspopup": "false", "aria-expanded": "false") do
           - if current_user.avatar.attached?
             = image_tag current_user.avatar, class: "rounded-circle-sm"
@@ -13,6 +21,8 @@
           = link_to "設定", :edit_user_registration, class: "dropdown-item"
           = link_to "ログアウト", :destroy_user_session, method: :delete, class: "dropdown-item"
     - else
-      %li.nav-item
-        = link_to 'ログイン', :new_user_session
-        = link_to 'サインアップ', :new_user_registration
+      %ul.navbar-nav.ml-auto
+        %li.nav-item.mr-1
+          = link_to 'ログイン', :new_user_session
+        %li.nav-item
+          = link_to 'サインアップ', :new_user_registration

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -8,7 +8,7 @@
     - if user_signed_in?
       %ul.navbar-nav.mr-auto
         %li.nav-item
-          = link_to root_path do
+          = link_to :users do
             = fa_icon "users", text: "ユーザー"
       .nav-item.dropdown
         = link_to("#", id: "navbarDropdownMenuLink", class: "nav-link dropdown-toggle", "data-toggle": "dropdown", "data-flip": "true", "aria-haspopup": "false", "aria-expanded": "false") do

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -12,7 +12,7 @@
             = fa_icon "users", text: "ユーザー"
       .nav-item.dropdown
         = link_to("#", id: "navbarDropdownMenuLink", class: "nav-link dropdown-toggle", "data-toggle": "dropdown", "data-flip": "true", "aria-haspopup": "false", "aria-expanded": "false") do
-          = avatar_image(current_user)
+          = avatar_image(current_user, 'rounded-circle-sm')
         .dropdown-menu.dropdown-menu-right{"aria-labelledby": "navbarDropdownMenuLink", style: "position: absolute;right: 0;left: auto;"}
           = link_to "プロフィール", current_user, class: "dropdown-item"
           = link_to "設定", :edit_user_registration, class: "dropdown-item"

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -5,9 +5,9 @@
       %li.nav-item.dropdown
         = link_to("#", id: "navbarDropdownMenuLink", class: "nav-link dropdown-toggle", "data-toggle": "dropdown", "data-flip": "true", "aria-haspopup": "false", "aria-expanded": "false") do
           - if current_user.avatar.attached?
-            = image_tag current_user.avatar, class: "rounded-circle"
+            = image_tag current_user.avatar, class: "rounded-circle-sm"
           - else
-            = image_tag '/no_image.png', class: "rounded-circle"
+            = image_tag '/no_image.png', class: "rounded-circle-sm"
         .dropdown-menu.dropdown-menu-right{"aria-labelledby": "navbarDropdownMenuLink", style: "position: absolute;right: 0;left: auto;"}
           = link_to "プロフィール編集", :edit_user_registration, class: "dropdown-item"
           = link_to "ログアウト", :destroy_user_session, method: :delete, class: "dropdown-item"

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -9,7 +9,8 @@
           - else
             = image_tag '/no_image.png', class: "rounded-circle-sm"
         .dropdown-menu.dropdown-menu-right{"aria-labelledby": "navbarDropdownMenuLink", style: "position: absolute;right: 0;left: auto;"}
-          = link_to "プロフィール編集", :edit_user_registration, class: "dropdown-item"
+          = link_to "プロフィール", current_user, class: "dropdown-item"
+          = link_to "設定", :edit_user_registration, class: "dropdown-item"
           = link_to "ログアウト", :destroy_user_session, method: :delete, class: "dropdown-item"
     - else
       %li.nav-item

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -1,22 +1,22 @@
 %nav.navbar.navbar-expand-lg.navbar-light.bg-light
   .navbar-brand
     = link_to :root do
-      = fa_icon "home", text: "ホーム"
-  %button.navbar-toggler{"aria-controls" => "navbarText", "aria-expanded" => "false", "aria-label" => "Toggle navigation", "data-target" => "#navbarText", "data-toggle" => "collapse", :type => "button"}
+      = fa_icon 'home', text: 'ホーム'
+  %button.navbar-toggler{'aria-controls' => 'navbarText', 'aria-expanded' => 'false', 'aria-label' => 'Toggle navigation', 'data-target' => '#navbarText', 'data-toggle' => 'collapse', :type => 'button'}
     %span.navbar-toggler-icon
   #navbarText.collapse.navbar-collapse
     - if user_signed_in?
       %ul.navbar-nav.mr-auto
         %li.nav-item
           = link_to :users do
-            = fa_icon "users", text: "ユーザー"
+            = fa_icon 'users', text: 'ユーザー'
       .nav-item.dropdown
-        = link_to("#", id: "navbarDropdownMenuLink", class: "nav-link dropdown-toggle", "data-toggle": "dropdown", "data-flip": "true", "aria-haspopup": "false", "aria-expanded": "false") do
+        = link_to('#', id: 'navbarDropdownMenuLink', class: 'nav-link dropdown-toggle', 'data-toggle': 'dropdown', 'data-flip': 'true', 'aria-haspopup': 'false', 'aria-expanded': 'false') do
           = avatar_image(current_user, 'rounded-circle-sm')
-        .dropdown-menu.dropdown-menu-right{"aria-labelledby": "navbarDropdownMenuLink", style: "position: absolute;right: 0;left: auto;"}
-          = link_to "プロフィール", current_user, class: "dropdown-item"
-          = link_to "設定", :edit_user_registration, class: "dropdown-item"
-          = link_to "ログアウト", :destroy_user_session, method: :delete, class: "dropdown-item"
+        .dropdown-menu.dropdown-menu-right{'aria-labelledby': 'navbarDropdownMenuLink', style: 'position: absolute;right: 0;left: auto;'}
+          = link_to 'プロフィール', current_user, class: 'dropdown-item'
+          = link_to '設定', :edit_user_registration, class: 'dropdown-item'
+          = link_to 'ログアウト', :destroy_user_session, method: :delete, class: 'dropdown-item'
     - else
       %ul.navbar-nav.ml-auto
         %li.nav-item.mr-1

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,7 +1,7 @@
 !!!
 %html
   %head
-    %meta{content: "text/html; charset=UTF-8", "http-equiv": "Content-Type"}/
+    %meta{content: 'text/html; charset=UTF-8', 'http-equiv': 'Content-Type'}/
     %title TwitterClone
     = csrf_meta_tags
     = csp_meta_tag

--- a/app/views/tweets/_tweet.html.haml
+++ b/app/views/tweets/_tweet.html.haml
@@ -1,7 +1,7 @@
 .list-group-item.list-group-item-action.flex-column.align-items-start
   .row
     .col-1.px-2
-      = avatar_image(tweet.user)
+      = avatar_image(tweet.user, 'rounded-circle-sm')
     .col-10.px-3
       %p.my-1
         %strong

--- a/app/views/tweets/_tweet.html.haml
+++ b/app/views/tweets/_tweet.html.haml
@@ -1,0 +1,19 @@
+.list-group-item.list-group-item-action.flex-column.align-items-start
+  .row
+    .col-1.px-2
+      - if tweet.user.avatar.attached?
+        = image_tag tweet.user.avatar, class: "rounded-circle-sm"
+      - else
+        = image_tag '/no_image.png', class: "rounded-circle-sm"
+    .col-10.px-3
+      %p.my-1
+        %strong
+          = link_to "#{tweet.user.name}", tweet.user
+        ・
+        %span.text-secondary
+          = time_ago_in_words(tweet.created_at)
+          前
+      = tweet.content
+    .col-1.px-1
+      - if tweet.user_id == current_user.id
+        = link_to '削除', tweet, method: :delete, data: { confirm: '本当に削除しますか？' }

--- a/app/views/tweets/index.html.haml
+++ b/app/views/tweets/index.html.haml
@@ -10,9 +10,9 @@
           .row
             .col-1.px-2
               - if tweet.user.avatar.attached?
-                = image_tag tweet.user.avatar, class: "rounded-circle"
+                = image_tag tweet.user.avatar, class: "rounded-circle-sm"
               - else
-                = image_tag '/no_image.png', class: "rounded-circle"
+                = image_tag '/no_image.png', class: "rounded-circle-sm"
             .col-10.px-3
               %p.my-1
                 %strong= "#{tweet.user.name}"

--- a/app/views/tweets/index.html.haml
+++ b/app/views/tweets/index.html.haml
@@ -3,7 +3,7 @@
     .list-group
       .list-group-item.list-group-item-action.flex-column.align-items-start.list-group-item-primary
         = simple_form_for @tweet do |f|
-          = f.input :content, label: false, placeholder: "いまどうしてる？"
+          = f.input :content, label: false, placeholder: 'いまどうしてる？'
           = f.submit 'ツイート', class: "btn btn-primary badge-pill float-right"
-      = render partial: "tweet", collection: @tweets
+      = render partial: 'tweet', collection: @tweets
     = paginate @tweets

--- a/app/views/tweets/index.html.haml
+++ b/app/views/tweets/index.html.haml
@@ -5,23 +5,5 @@
         = simple_form_for Tweet.new do |f|
           = f.input :content, label: false, placeholder: "いまどうしてる？"
           = f.submit 'ツイート', class: "btn btn-primary badge-pill float-right"
-      - @tweets.each do |tweet|
-        .list-group-item.list-group-item-action.flex-column.align-items-start
-          .row
-            .col-1.px-2
-              - if tweet.user.avatar.attached?
-                = image_tag tweet.user.avatar, class: "rounded-circle-sm"
-              - else
-                = image_tag '/no_image.png', class: "rounded-circle-sm"
-            .col-10.px-3
-              %p.my-1
-                %strong= "#{tweet.user.name}"
-                ・
-                %span.text-secondary
-                  = time_ago_in_words(tweet.created_at)
-                  前
-              = tweet.content
-            .col-1.px-1
-              - if tweet.user_id == current_user.id
-                = link_to '削除', tweet, method: :delete, data: { confirm: '本当に削除しますか？' }
+      = render partial: "tweet", collection: @tweets
     = paginate @tweets

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,10 +1,10 @@
 .row
   .col-md-6.offset-md-3
     .list-group
-      .list-group-item.list-group-item-action.flex-column.align-items-start
+      .list-group-item.flex-column.align-items-start
         %h4.mb-1 おすすめユーザー
         %p.mb-1 以下のおすすめユーザーをフォローしてみましょう。
-      .list-group-item.list-group-item-action.flex-column.align-items-start.list-group-item-secondary
+      .list-group-item.flex-column.align-items-start.list-group-item-secondary
         = form_with url: :users, method: :get, local: true do |f|
           .form-group.row
             .col-md-9

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -5,10 +5,10 @@
         %h4.mb-1 おすすめユーザー
         %p.mb-1 以下のおすすめユーザーをフォローしてみましょう。
       .list-group-item.list-group-item-action.flex-column.align-items-start.list-group-item-secondary
-        = form_with url: :search_users, method: :get, local: true do |f|
+        = form_with url: :users, method: :get, local: true do |f|
           .form-group.row
             .col-md-9
-              = f.text_field :search, class: 'form-control'
+              = f.text_field :keyword, class: 'form-control'
             .col-md-3.pl-0
               = f.submit 'キーワード検索', class: 'btn btn-primary badge-pill', name: nil
       - @users.each do |user|

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -8,7 +8,7 @@
         = form_with url: :search, method: :get, local: true do |f|
           .form-group.row
             .col-md-9
-              = f.text_field :name, class: 'form-control'
+              = f.text_field :search, class: 'form-control'
             .col-md-3.pl-0
               = f.submit 'キーワード検索', class: 'btn btn-primary badge-pill', name: nil
       - @users.each do |user|

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -21,6 +21,4 @@
                 %strong
                   = link_to "#{user.name}", user
               = user.profile
-            .col-3.px-1
-              = link_to 'フォローする', '#', class: 'btn btn-outline-primary badge-pill'
     = paginate @users

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,0 +1,18 @@
+.row
+  .col-md-6.offset-md-3
+    .list-group
+      .list-group-item.list-group-item-action.flex-column.align-items-start
+        %h4.mb-1 おすすめユーザー
+        %p.mb-1 以下のおすすめユーザーをフォローしてみましょう。
+      - @users.each do |user|
+        .list-group-item.list-group-item-action.flex-column.align-items-start
+          .row
+            .col-1.px-2
+              = avatar_image(user, 'rounded-circle-sm')
+            .col-8.px-3
+              %p.my-1
+                %strong
+                  = link_to "#{user.name}", user
+              自己紹介文自己紹介文自己紹介文自己紹介文自己紹介文自己紹介文自己紹介文自己紹介文自己紹介文自己紹介文
+            .col-3.px-1
+              = link_to 'フォローする', '#', class: 'btn btn-outline-primary badge-pill'

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -20,6 +20,6 @@
               %p.my-1
                 %strong
                   = link_to "#{user.name}", user
-              自己紹介文自己紹介文自己紹介文自己紹介文自己紹介文自己紹介文自己紹介文自己紹介文自己紹介文自己紹介文
+              = user.profile
             .col-3.px-1
               = link_to 'フォローする', '#', class: 'btn btn-outline-primary badge-pill'

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -23,3 +23,4 @@
               = user.profile
             .col-3.px-1
               = link_to 'フォローする', '#', class: 'btn btn-outline-primary badge-pill'
+    = paginate @users

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -5,7 +5,7 @@
         %h4.mb-1 おすすめユーザー
         %p.mb-1 以下のおすすめユーザーをフォローしてみましょう。
       .list-group-item.list-group-item-action.flex-column.align-items-start.list-group-item-secondary
-        = form_with url: :search, method: :get, local: true do |f|
+        = form_with url: :search_users, method: :get, local: true do |f|
           .form-group.row
             .col-md-9
               = f.text_field :search, class: 'form-control'

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -4,6 +4,13 @@
       .list-group-item.list-group-item-action.flex-column.align-items-start
         %h4.mb-1 おすすめユーザー
         %p.mb-1 以下のおすすめユーザーをフォローしてみましょう。
+      .list-group-item.list-group-item-action.flex-column.align-items-start.list-group-item-secondary
+        = form_with url: :search, method: :get, local: true do |f|
+          .form-group.row
+            .col-md-9
+              = f.text_field :name, class: 'form-control'
+            .col-md-3.pl-0
+              = f.submit 'キーワード検索', class: 'btn btn-primary badge-pill', name: nil
       - @users.each do |user|
         .list-group-item.list-group-item-action.flex-column.align-items-start
           .row

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -9,3 +9,4 @@
             = @user.profile
   .col-md-6.col-12
     = render partial: "tweets/tweet", collection: @tweets
+    = paginate @tweets

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -6,6 +6,6 @@
         %h4.card-title= "#{@user.name}"
         %p.card-text
           %span.text-secondary
-            あとで自己紹介カラム追加予定。。。。。。。
+            = @user.profile
   .col-md-6.col-12
     = render partial: "tweets/tweet", collection: @tweets

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,10 +1,7 @@
 .row
   .col-md-3.col-12.d-none.d-md-block
     .card.p-2.border-light
-      - if @user.avatar.attached?
-        = image_tag @user.avatar, class: "mx-auto card-img-top rounded-circle-lg"
-      - else
-        = image_tag '/no_image.png', class: "mx-auto card-img-top rounded-circle-lg"
+      = avatar_image(current_user, 'mx-auto card-img-top rounded-circle-lg')
       .card-body
         %h4.card-title= "#{@user.name}"
         %p.card-text

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -8,5 +8,5 @@
           %span.text-secondary
             = @user.profile
   .col-md-6.col-12
-    = render partial: "tweets/tweet", collection: @tweets
+    = render partial: 'tweets/tweet', collection: @tweets
     = paginate @tweets

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,0 +1,14 @@
+.row
+  .col-md-3.col-12.d-none.d-md-block
+    .card.p-2.border-light
+      - if @user.avatar.attached?
+        = image_tag @user.avatar, class: "mx-auto card-img-top rounded-circle-lg"
+      - else
+        = image_tag '/no_image.png', class: "mx-auto card-img-top rounded-circle-lg"
+      .card-body
+        %h4.card-title= "#{@user.name}"
+        %p.card-text
+          %span.text-secondary
+            あとで自己紹介カラム追加予定。。。。。。。
+  .col-md-6.col-12
+    = render partial: "tweets/tweet", collection: @tweets

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,7 +1,7 @@
 .row
   .col-md-3.col-12.d-none.d-md-block
     .card.p-2.border-light
-      = avatar_image(current_user, 'mx-auto card-img-top rounded-circle-lg')
+      = avatar_image(@user, 'mx-auto card-img-top rounded-circle-lg')
       .card-body
         %h4.card-title= "#{@user.name}"
         %p.card-text

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -35,3 +35,6 @@ ja:
       over_x_years:
         one:   "1年以上"
         other: "%{count}年以上"
+  views:
+    pagination:
+      truncate: "..."

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -8,6 +8,7 @@ ja:
         avatar: "プロフィール画像"
         title: "タイトル"
         email: "メールアドレス"
+        profile: "プロフィール"
         current_password: "現在のパスワード"
         password: "パスワード"
         password_confirmation: "確認用パスワード"

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -34,3 +34,4 @@ ja:
         equal_to: "は%{count}を指定してください。"
         less_than: "は%{count}より小さい値を指定してください。"
         less_than_or_equal_to: "は%{count}以下の値を指定してください。"
+        record_invalid: "バリデーションに失敗しました。 %{errors}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'tweets#index'
-  resources :users, only: %i(index show) do
-    collection do
-      get :search
-    end
-  end
+  resources :users, only: %i(index show)
   resources :tweets, only: %i(create destroy)
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   root 'tweets#index'
   resources :users, only: %i(index show)
   resources :tweets, only: %i(create destroy)
+  get 'search', to: 'users#search'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'tweets#index'
-  resources :users, only: %i(show)
+  resources :users, only: %i(index show)
   resources :tweets, only: %i(create destroy)
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root 'tweets#index'
   resources :tweets, only: [:create, :destroy]
+  resources :users, :only => [:show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,10 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'tweets#index'
-  resources :users, only: %i(index show)
+  resources :users, only: %i(index show) do
+    collection do
+      get :search
+    end
+  end
   resources :tweets, only: %i(create destroy)
-  get 'search', to: 'users#search'
 end

--- a/db/migrate/20180610225212_add_profile_to_user.rb
+++ b/db/migrate/20180610225212_add_profile_to_user.rb
@@ -1,0 +1,5 @@
+class AddProfileToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :profile, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_02_093026) do
+ActiveRecord::Schema.define(version: 2018_06_10_225212) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 2018_06_02_093026) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name"
+    t.text "profile"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["name"], name: "index_users_on_name", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/seeds/tweets.rb
+++ b/db/seeds/tweets.rb
@@ -1,4 +1,4 @@
-3.times do |i|
+5.times do |i|
   User.find_each do |user|
     puts "\"#{user.name}\" posted something!"
     user.tweets.create({ content: Faker::Hacker.say_something_smart, user_id: user.id })

--- a/db/seeds/users.rb
+++ b/db/seeds/users.rb
@@ -1,8 +1,9 @@
-3.times do
+12.times do
   user = User.create({
     name: Faker::Internet.unique.user_name,
     email: Faker::Internet.unique.email,
-    password: Faker::Internet.password(8)
+    password: Faker::Internet.password(8),
+    profile: Faker::Lorem.sentence
   })
   puts "\"#{user.name}\" has created!"
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
-    name Faker::Internet.unique.user_name
-    email Faker::Internet.unique.email
+    sequence(:name) { |n| "test#{n}" }
+    sequence(:email) { |n| "test#{n}@example.com" }
     password Faker::Internet.password(8)
   end
 end

--- a/spec/features/tweets_spec.rb
+++ b/spec/features/tweets_spec.rb
@@ -1,33 +1,33 @@
 require 'rails_helper'
 
-RSpec.feature "Tweets", type: :feature do
+RSpec.feature 'Tweets', type: :feature do
 
-  scenario "user creates a new tweet" do
+  scenario 'user creates a new tweet' do
     user = create(:user)
 
     login_as user, scope: :user
     visit root_path
 
     expect {
-      fill_in "tweet_content", with: "Trying out Capybara"
-      click_button "ツイート"
-      expect(page).to have_content "投稿しました"
+      fill_in 'tweet_content', with: 'Trying out Capybara'
+      click_button 'ツイート'
+      expect(page).to have_content '投稿しました'
     }.to change(user.tweets, :count).by(1)
   end
 
-  scenario "user can't creates a new tweet without content" do
+  scenario 'user can not creates a new tweet without content' do
     user = create(:user)
 
     login_as user, scope: :user
     visit root_path
 
     expect {
-      click_button "ツイート"
-      expect(page).to have_content "投稿に失敗しました"
+      click_button 'ツイート'
+      expect(page).to have_content '投稿に失敗しました'
     }.not_to change(user.tweets, :count)
   end
 
-  scenario "user delete a new tweet" do
+  scenario 'user delete a new tweet' do
     user = create(:user)
     create(:tweet, user: user)
 
@@ -35,8 +35,8 @@ RSpec.feature "Tweets", type: :feature do
     visit root_path
 
     expect {
-      click_link "削除"
-      expect(page).to have_content "削除しました"
+      click_link '削除'
+      expect(page).to have_content '削除しました'
     }.to change(user.tweets, :count).by(-1)
   end
 end

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.feature "Users", type: :feature do
-  scenario "visit user index" do
+RSpec.feature 'Users', type: :feature do
+  scenario 'visit user index' do
     user = create(:user)
     login_as user, scope: :user
 
@@ -11,7 +11,7 @@ RSpec.feature "Users", type: :feature do
     expect(page).to have_selector('.list-group-item', count: 8)
   end
 
-  scenario "search users" do
+  scenario 'search users' do
     user = create(:user)
     login_as user, scope: :user
 
@@ -20,12 +20,12 @@ RSpec.feature "Users", type: :feature do
     create(:user, name: 'John', profile: 'John')
     visit users_path
 
-    fill_in "keyword", with: 'Bob'
-    click_button "キーワード検索"
+    fill_in 'keyword', with: 'Bob'
+    click_button 'キーワード検索'
     expect(page).to have_selector('.list-group-item', count: 4)
   end
 
-  scenario "visit user show" do
+  scenario 'visit user show' do
     user = create(:user)
     login_as user, scope: :user
 

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Users", type: :feature do
     create(:user, name: 'John', profile: 'John')
     visit users_path
 
-    fill_in "search", with: 'Bob'
+    fill_in "keyword", with: 'Bob'
     click_button "キーワード検索"
     expect(page).to have_selector('.list-group-item', count: 4)
   end

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Users', type: :feature do
     create_list(:user, 5)
     visit users_path
 
-    expect(page).to have_selector('.list-group-item', count: 8)
+    expect(page).to have_selector('.list-group-item-action', count: 6)
   end
 
   scenario 'search users' do
@@ -22,7 +22,7 @@ RSpec.feature 'Users', type: :feature do
 
     fill_in 'keyword', with: 'Bob'
     click_button 'キーワード検索'
-    expect(page).to have_selector('.list-group-item', count: 4)
+    expect(page).to have_selector('.list-group-item-action', count: 2)
   end
 
   scenario 'visit user show' do

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.feature "Users", type: :feature do
+  scenario "visit user index" do
+    user = create(:user)
+    login_as user, scope: :user
+
+    create_list(:user, 5)
+    visit users_path
+
+    expect(page).to have_selector('.list-group-item', count: 8)
+  end
+end

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -24,4 +24,14 @@ RSpec.feature "Users", type: :feature do
     click_button "キーワード検索"
     expect(page).to have_selector('.list-group-item', count: 4)
   end
+
+  scenario "visit user show" do
+    user = create(:user)
+    login_as user, scope: :user
+
+    create_list(:tweet, 3, user: user)
+    visit users_path(user)
+
+    expect(page).to have_selector('.list-group-item', count: 3)
+  end
 end

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -10,4 +10,18 @@ RSpec.feature "Users", type: :feature do
 
     expect(page).to have_selector('.list-group-item', count: 8)
   end
+
+  scenario "search users" do
+    user = create(:user)
+    login_as user, scope: :user
+
+    create(:user, name: 'Bob')
+    create(:user, profile: 'Bob')
+    create(:user, name: 'John', profile: 'John')
+    visit users_path
+
+    fill_in "search", with: 'Bob'
+    click_button "キーワード検索"
+    expect(page).to have_selector('.list-group-item', count: 4)
+  end
 end

--- a/spec/models/tweet_spec.rb
+++ b/spec/models/tweet_spec.rb
@@ -3,21 +3,21 @@ require 'rails_helper'
 RSpec.describe Tweet, type: :model do
   let(:user) { create(:user) }
 
-  it "is valid with a content" do
+  it 'is valid with a content' do
     tweet = build(:tweet, user: user)
     expect(tweet).to be_valid
   end
 
-  it "is invalid without a content" do
+  it 'is invalid without a content' do
     tweet = build(:tweet, content: nil)
     tweet.valid?
-    expect(tweet.errors[:content]).to include("が記入されていません。")
+    expect(tweet.errors[:content]).to include('が記入されていません。')
   end
 
-  it "is invalid with over 280 characters" do
-    content = "a" * 281
+  it 'is invalid with over 280 characters' do
+    content = 'a' * 281
     tweet = build(:tweet, content: content)
     tweet.valid?
-    expect(tweet.errors[:content]).to include("は280文字以内で記入してください。")
+    expect(tweet.errors[:content]).to include('は280文字以内で記入してください。')
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+
   it "is valid with a name" do
     expect(build(:user)).to be_valid
   end
@@ -9,5 +10,47 @@ RSpec.describe User, type: :model do
     user = build(:user, name: nil)
     user.valid?
     expect(user.errors[:name]).to include("が記入されていません。")
+  end
+
+  it "is invalid without a name" do
+    user = build(:user, name: nil)
+    user.valid?
+    expect(user.errors[:name]).to include("が記入されていません。")
+  end
+
+  describe "search users by a keyword" do
+    let!(:user1) {
+      create(:user, name: 'Bob', profile: 'first')
+    }
+    let!(:user2) {
+      create(:user, name: 'John', profile: 'second')
+    }
+    let!(:user3) {
+      create(:user, name: 'Alisa', profile: 'third')
+    }
+
+    context "when a match is found" do
+      it "returns users that match the search name" do
+        expect(User.search("Bob")).to include(user1)
+      end
+    end
+
+    context "when a match is found" do
+      it "returns users that match the search profile" do
+        expect(User.search("second")).to include(user2)
+      end
+    end
+
+    context "when no match is found" do
+      it "returns an empty collection" do
+        expect(User.search("test")).to be_empty
+      end
+    end
+
+    context "when no match is found" do
+      it "returns an empty collection" do
+        expect(User.search("")).to include(user1, user2, user3)
+      end
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,23 +2,23 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
 
-  it "is valid with a name" do
+  it 'is valid with a name' do
     expect(build(:user)).to be_valid
   end
 
-  it "is invalid without a name" do
+  it 'is invalid without a name' do
     user = build(:user, name: nil)
     user.valid?
-    expect(user.errors[:name]).to include("が記入されていません。")
+    expect(user.errors[:name]).to include('が記入されていません。')
   end
 
-  it "is invalid without a name" do
+  it 'is invalid without a name' do
     user = build(:user, name: nil)
     user.valid?
-    expect(user.errors[:name]).to include("が記入されていません。")
+    expect(user.errors[:name]).to include('が記入されていません。')
   end
 
-  describe "search users by a keyword" do
+  describe 'search users by a keyword' do
     let!(:user1) {
       create(:user, name: 'Bob', profile: 'first')
     }
@@ -29,27 +29,27 @@ RSpec.describe User, type: :model do
       create(:user, name: 'Alisa', profile: 'third')
     }
 
-    context "when a match is found" do
-      it "returns users that match the search name" do
-        expect(User.search("Bob")).to include(user1)
+    context 'when a match is found' do
+      it 'returns users that match the search name' do
+        expect(User.search('Bob')).to include(user1)
       end
     end
 
-    context "when a match is found" do
-      it "returns users that match the search profile" do
-        expect(User.search("second")).to include(user2)
+    context 'when a match is found' do
+      it 'returns users that match the search profile' do
+        expect(User.search('second')).to include(user2)
       end
     end
 
-    context "when no match is found" do
-      it "returns an empty collection" do
-        expect(User.search("test")).to be_empty
+    context 'when no match is found' do
+      it 'returns an empty collection' do
+        expect(User.search('test')).to be_empty
       end
     end
 
-    context "when no match is found" do
-      it "returns an empty collection" do
-        expect(User.search("")).to include(user1, user2, user3)
+    context 'when no match is found' do
+      it 'returns an empty collection' do
+        expect(User.search('')).to include(user1, user2, user3)
       end
     end
   end


### PR DESCRIPTION
# Issue
#4 

# 内容
- [ ] ユーザの一覧画面（ヘッダーの「ユーザ」から遷移）
- [ ] ユーザの検索機能（名前とプロフィールからキーワード検索）
- [ ] ユーザの詳細画面とそのツイート一覧
- [ ] 一覧表示と詳細画面のテスト

# 画像イメージ
<img width="1240" alt="2018-06-13 20 37 32" src="https://user-images.githubusercontent.com/18512510/41349081-b14ec66e-6f49-11e8-9e78-47b9bf35c2ae.png">
<img width="1241" alt="2018-06-13 20 37 53" src="https://user-images.githubusercontent.com/18512510/41349088-b535f66c-6f49-11e8-96a3-ff221be40e01.png">
